### PR TITLE
Fixed plugin 'googles.py'

### DIFF
--- a/plugins/google.py
+++ b/plugins/google.py
@@ -36,6 +36,6 @@ class Plugin:
     def __init__(self, app, conf):#
         global app_emailharvester, config
         #config = conf
-        app.register_plugin('googles', {'search': search})
+        app.register_plugin('google', {'search': search})
         app_emailharvester = app
         


### PR DESCRIPTION
Changed name of plugin from 'googles.py' to 'google.py'. Changed misstype 'googles' to 'google' in plugin. Because of these, the first example in the documentation didn't work.